### PR TITLE
feat: add deploy script for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Open the printed URL (usually http://localhost:5173).
 npm run build
 npm run preview
 ```
+
+## Deploy
+Build the site and publish the `dist/` directory to GitHub Pages:
+
+```bash
+npm run deploy
+```

--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body class="bg-neutral-50">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "vite build && gh-pages -d dist"
   },
   "dependencies": {
     "html-to-image": "^1.11.11",


### PR DESCRIPTION
## Summary
- add `deploy` script for publishing built site with `gh-pages`
- document how to deploy
- use relative path for entry script in `index.html`

## Testing
- `npm run build` *(fails: [plugin:vite:esbuild] [plugin vite:esbuild] src/App.jsx: Duplicate key "crop" in object literal)*


------
https://chatgpt.com/codex/tasks/task_e_689bcef70adc8329a6107aa04cdb104d