### PR TITLE
configure Vite base path for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,15 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+const base = process.env.VITE_BASE_PATH || '/ML-Moodboard-Maker/'
+
 export default defineConfig({
-  base: './',
+  base,
   plugins: [react()],
-  resolve: { alias: { '@': path.resolve(__dirname, 'src') } }
+  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+  build: {
+    rollupOptions: {
+      external: ['@tauri-apps/api/dialog', '@tauri-apps/api/fs']
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- set Vite's `base` to `/ML-Moodboard-Maker/` by default and allow overriding with `VITE_BASE_PATH`
- externalize Tauri API modules during build to avoid resolution errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bcef5c140832981644462d36ab5ff