### PR TITLE
Handle localStorage quota errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,7 +73,18 @@ export default function MoodboardMaker() {
     }
   }, []);
   useEffect(() => {
-    localStorage.setItem("assets", JSON.stringify(assets));
+    try {
+      localStorage.setItem("assets", JSON.stringify(assets));
+    } catch (err) {
+      if (err && (err.name === "QuotaExceededError" || err.code === 22)) {
+        if (!isTauri()) {
+          alert("Storage limit reached. Please remove some images to continue.");
+        }
+        console.warn("Failed to persist assets: storage quota exceeded");
+      } else {
+        console.warn("Failed to persist assets", err);
+      }
+    }
   }, [assets]);
   const layoutStyle = useMemo(() => {
     if (layoutMode === "auto") return { columnCount: columns, columnGap: `${gap}px` };


### PR DESCRIPTION
## Summary
- prevent app from crashing when asset persistence exceeds storage quota
- inform user when persistence fails due to storage limit

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c0e4d15d88329bd3aba2ad88f4b96