### PR TITLE
fix: correct build version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-moodboard-maker",
-  "version": "1.3.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-moodboard-maker",
-      "version": "1.3.0",
+      "version": "1.0.3",
       "dependencies": {
         "html-to-image": "^1.11.11",
         "jspdf": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-moodboard-maker",
-  "version": "1.3.0",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- fix version number from 1.3.0 to 1.0.3

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce3f6dc9883298136af3e1c207105