### PR TITLE
Toggle asset panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -386,7 +386,7 @@ export default function MoodboardMaker() {
         <Button variant="outline" size="sm" onClick={addFromUrl}>
           <ImagePlus className="h-4 w-4 mr-1" />From URL
         </Button>
-        <Button variant="outline" size="sm" onClick={() => setAssetPanelOpen(true)}>
+        <Button variant="outline" size="sm" onClick={() => setAssetPanelOpen((prev) => !prev)}>
           <LayoutGrid className="h-4 w-4 mr-1" />Assets
         </Button>
         <Button variant="ghost" size="sm" onClick={resetOrder}>


### PR DESCRIPTION
## Summary
- toggle AssetPanel visibility from the Assets button

## Testing
- `npm test` *(fails: Missing script "test" as no tests are configured)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf4d5246883298739f4655862b899