### PR TITLE
Ensure exports honor template dimensions

### DIFF
--- a/src/components/TemplateSelector.jsx
+++ b/src/components/TemplateSelector.jsx
@@ -5,8 +5,8 @@ export const TEMPLATES = [
   { id: "ig-square", name: "IG Square", columns: 3, gap: 4, padding: 0, canvasWidth: 1080, canvasHeight: 1080 },
   { id: "a4", name: "A4", columns: 4, gap: 12, padding: 24, canvasWidth: 2480, canvasHeight: 3508 },
   { id: "a3", name: "A3", columns: 4, gap: 12, padding: 24, canvasWidth: 3508, canvasHeight: 4961 },
-  { id: "16-9", name: "16:9", columns: 4, gap: 12, padding: 24, aspectRatio: 16 / 9 },
-  { id: "pinterest", name: "Pinterest", columns: 3, gap: 8, padding: 20, aspectRatio: 2 / 3 },
+  { id: "16-9", name: "16:9", columns: 4, gap: 12, padding: 24, canvasWidth: 1920, canvasHeight: 1080, aspectRatio: 16 / 9 },
+  { id: "pinterest", name: "Pinterest", columns: 3, gap: 8, padding: 20, canvasWidth: 1000, canvasHeight: 1500, aspectRatio: 2 / 3 },
 ];
 
 export default function TemplateSelector({ value, onChange }) {


### PR DESCRIPTION
## Summary
- add explicit canvas sizes for 16:9 and Pinterest templates
- snapshot helper sets board dimensions for html-to-image
- PDF export now matches board size and orientation

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d26429578832992251eafe8a325f8