### PR TITLE
refactor: centralize cx utility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,8 +17,7 @@ import SafeMarginOverlay from "@/components/SafeMarginOverlay";
 import VirtualImage from "@/components/VirtualImage";
 import pkg from "../package.json";
 import { zipSync, unzipSync, strToU8, strFromU8 } from "fflate";
-
-const cx = (...cls) => cls.filter(Boolean).join(" ");
+import { cx } from "@/utils/cx";
 const isTauri = () => typeof window !== "undefined" && (window.__TAURI__ || window.__TAURI_IPC__ || window.__TAURI_INTERNALS__);
 /** @typedef {{x:number,y:number,zoom:number}} Crop */
 /** @typedef {{id:string, src:string, w?:number, h?:number, crop?:Crop}} BoardImage */

--- a/src/components/AssetPanel.jsx
+++ b/src/components/AssetPanel.jsx
@@ -2,8 +2,7 @@ import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { LayoutGrid, Trash2 } from "lucide-react";
-
-const cx = (...cls) => cls.filter(Boolean).join(" ");
+import { cx } from "@/utils/cx";
 
 /**
  * @typedef {{id:string, src:string, name:string, w?:number, h?:number}} Asset

--- a/src/components/SettingsDrawer.jsx
+++ b/src/components/SettingsDrawer.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Settings2 } from "lucide-react";
-
-const cx = (...cls) => cls.filter(Boolean).join(" ");
+import { cx } from "@/utils/cx";
 
 export default function SettingsDrawer({ open, onToggle, children }) {
   return (

--- a/src/utils/cx.js
+++ b/src/utils/cx.js
@@ -1,0 +1,1 @@
+export const cx = (...cls) => cls.filter(Boolean).join(" ");


### PR DESCRIPTION
## Summary
- add reusable `cx` helper for conditional class concatenation
- use shared `cx` in `App`, `AssetPanel`, and `SettingsDrawer`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c435bec14c832986d92fbf34167836