### PR TITLE
feat: add TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "typescript": "^5.9.2",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7"
   }
 }

--- a/src/components/AssetPanel.tsx
+++ b/src/components/AssetPanel.tsx
@@ -3,12 +3,17 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { LayoutGrid, Trash2 } from "lucide-react";
 import { cx } from "@/utils/cx";
+import { Asset } from "@/types";
 
-/**
- * @typedef {{id:string, src:string, name:string, w?:number, h?:number}} Asset
- */
+interface AssetPanelProps {
+  assets: Asset[];
+  open: boolean;
+  onToggle: () => void;
+  onRemoveAsset: (id: string) => void;
+  onClearAssets: () => void;
+}
 
-export default function AssetPanel({ assets, open, onToggle, onRemoveAsset, onClearAssets }) {
+export default function AssetPanel({ assets, open, onToggle, onRemoveAsset, onClearAssets }: AssetPanelProps) {
   const [query, setQuery] = useState("");
   const filtered = assets.filter((a) => a.name.toLowerCase().includes(query.toLowerCase()));
 

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { Settings2 } from "lucide-react";
 import { cx } from "@/utils/cx";
 
-export default function SettingsDrawer({ open, onToggle, children }) {
+interface SettingsDrawerProps {
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}
+
+export default function SettingsDrawer({ open, onToggle, children }: SettingsDrawerProps) {
   return (
     <div className="fixed right-0 z-40 flex bottom-0" style={{ top: "var(--header-height)" }}>
       <button

--- a/src/components/VirtualImage.tsx
+++ b/src/components/VirtualImage.tsx
@@ -1,5 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 
+interface VirtualImageProps {
+  src: string;
+  alt: string;
+  force?: boolean;
+  wrapperClassName?: string;
+  wrapperStyle?: React.CSSProperties;
+  imgClassName?: string;
+  imgStyle?: React.CSSProperties;
+}
+
 export default function VirtualImage({
   src,
   alt,
@@ -8,8 +18,8 @@ export default function VirtualImage({
   wrapperStyle = {},
   imgClassName = "",
   imgStyle = {},
-}) {
-  const ref = useRef(null);
+}: VirtualImageProps) {
+  const ref = useRef<HTMLDivElement>(null);
   const [inView, setInView] = useState(false);
   const [loaded, setLoaded] = useState(false);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,24 @@
+export interface Asset {
+  id: string;
+  src: string;
+  name: string;
+  w?: number;
+  h?: number;
+}
+
+export interface Crop {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+export interface BoardImage {
+  id: string;
+  assetId: string;
+  src?: string;
+  w?: number;
+  h?: number;
+  colSpan?: number;
+  rowSpan?: number;
+  crop?: Crop;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,10 @@ const base = process.env.VITE_BASE_PATH || '/Method-Mosaic/'
 export default defineConfig({
   base,
   plugins: [react()],
-  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') },
+    extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json']
+  },
   build: {
     rollupOptions: {
       external: ['@tauri-apps/api/dialog', '@tauri-apps/api/fs']


### PR DESCRIPTION
## Summary
- add basic TypeScript configuration and type definitions
- convert AssetPanel, SettingsDrawer, and VirtualImage to TSX with typed props
- update Vite config for TypeScript resolution

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c45f13eff883299bcd2f4e9a145465