### PR TITLE
Add Vitest testing framework with sample tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "vite build && gh-pages -d dist"
+    "deploy": "vite build && gh-pages -d dist",
+    "test": "vitest"
   },
   "dependencies": {
     "html-to-image": "^1.11.11",
@@ -25,6 +26,9 @@
     "vite": "^5.4.2",
     "typescript": "^5.9.2",
     "@types/react": "^18.2.21",
-    "@types/react-dom": "^18.2.7"
+    "@types/react-dom": "^18.2.7",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/jest-dom": "^6.4.3"
   }
 }

--- a/src/components/__tests__/VirtualImage.test.jsx
+++ b/src/components/__tests__/VirtualImage.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+import VirtualImage from '../VirtualImage'
+
+// Mock Image to immediately resolve decoding
+class MockImage {
+  constructor() {
+    this.onload = null
+    this.onerror = null
+  }
+  set src(_src) {}
+  decode() { return Promise.resolve() }
+}
+
+global.Image = MockImage
+
+describe('VirtualImage', () => {
+  it('lazy loads image when it comes into view', async () => {
+    let observer
+    window.IntersectionObserver = vi.fn((callback) => {
+      observer = {
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+        trigger: (isIntersecting) => callback([{ isIntersecting, target: {} }])
+      }
+      return observer
+    })
+
+    render(<VirtualImage src="test.jpg" alt="demo" />)
+    expect(screen.queryByAltText('demo')).toBeNull()
+
+    observer.trigger(true)
+    expect(await screen.findByAltText('demo')).toBeInTheDocument()
+  })
+})

--- a/src/hooks/__tests__/useBoardState.test.js
+++ b/src/hooks/__tests__/useBoardState.test.js
@@ -1,0 +1,19 @@
+import { renderHook, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import useBoardState from '../useBoardState'
+
+describe('useBoardState undo/redo', () => {
+  it('reverts and reapplies state changes', () => {
+    const { result } = renderHook(() => useBoardState())
+
+    act(() => result.current.setBoardTitle('First'))
+    act(() => result.current.setBoardTitle('Second'))
+    expect(result.current.boardTitle).toBe('Second')
+
+    act(() => result.current.undo())
+    expect(result.current.boardTitle).toBe('First')
+
+    act(() => result.current.redo())
+    expect(result.current.boardTitle).toBe('Second')
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
@@ -18,5 +18,8 @@ export default defineConfig({
     rollupOptions: {
       external: ['@tauri-apps/api/dialog', '@tauri-apps/api/fs']
     }
+  },
+  test: {
+    environment: 'jsdom'
   }
 })


### PR DESCRIPTION
## Summary
- configure Vitest in Vite setup for jsdom environment
- add sample tests for `VirtualImage` lazy loading and `useBoardState` undo/redo
- expose `test` script and testing dependencies

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4606a325083298551886e0cf9eabb