### PR TITLE
feat: persist assets in IndexedDB with quota alert

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import useBoardState, { BRANDING_PRESETS, withDefaultCrop } from "@/hooks/useBoa
 import pkg from "../package.json";
 import { zipSync, unzipSync, strToU8, strFromU8 } from "fflate";
 import { cx } from "@/utils/cx";
+import { saveAssets, loadAssets } from "@/utils/storage";
 const isTauri = () => typeof window !== "undefined" && (window.__TAURI__ || window.__TAURI_IPC__ || window.__TAURI_INTERNALS__);
 export default function MethodMosaic() {
   const {
@@ -99,24 +100,37 @@ export default function MethodMosaic() {
   const canReorder = layoutMode !== "auto";
 
   useEffect(() => {
-    const stored = localStorage.getItem("assets");
-    if (stored) {
-      try { setAssets(JSON.parse(stored)); } catch {}
-    }
+    (async () => {
+      try {
+        const stored = await loadAssets();
+        if (stored) setAssets(stored);
+      } catch {
+        const stored = localStorage.getItem("assets");
+        if (stored) {
+          try { setAssets(JSON.parse(stored)); } catch {}
+        }
+      }
+    })();
   }, []);
   useEffect(() => {
-    try {
-      localStorage.setItem("assets", JSON.stringify(assets));
-    } catch (err) {
-      if (err && (err.name === "QuotaExceededError" || err.code === 22)) {
-        if (!isTauri()) {
-          // alert("Storage limit reached. Please remove some images to continue.");
+    (async () => {
+      try {
+        await saveAssets(assets);
+      } catch {
+        try {
+          localStorage.setItem("assets", JSON.stringify(assets));
+        } catch (err) {
+          if (err && (err.name === "QuotaExceededError" || err.code === 22)) {
+            if (!isTauri()) {
+              alert("Storage limit reached. Please remove some images to continue.");
+            }
+            console.warn("Failed to persist assets: storage quota exceeded");
+          } else {
+            console.warn("Failed to persist assets", err);
+          }
         }
-        console.warn("Failed to persist assets: storage quota exceeded");
-      } else {
-        console.warn("Failed to persist assets", err);
       }
-    }
+    })();
   }, [assets]);
 
   useEffect(() => {

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,41 @@
+const DB_NAME = 'method-mosaic';
+const STORE_NAME = 'assets';
+const KEY = 'assets';
+const VERSION = 1;
+
+function openDB() {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('IndexedDB not supported'));
+  }
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveAssets(assets) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.objectStore(STORE_NAME).put(assets, KEY);
+  });
+}
+
+export async function loadAssets() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(KEY);
+    req.onsuccess = () => resolve(req.result || null);
+    req.onerror = () => reject(req.error);
+  });
+}


### PR DESCRIPTION
## Summary
- add IndexedDB-based storage helpers
- persist assets via IndexedDB with localStorage fallback and alert on quota errors

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c47a014e688329b78aca2b6c31ad6a