### PR TITLE
feat: support configurable base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ npm run deploy   # Build and publish dist/ to GitHub Pages
 ```
 `npm run deploy` requires the [`gh-pages`](https://www.npmjs.com/package/gh-pages) CLI.
 
+## Deployment
+
+When hosting the app under a subpath (such as GitHub Pages), set the
+`VITE_BASE_PATH` environment variable to ensure assets are loaded from the
+correct base URL.
+
+```bash
+VITE_BASE_PATH=/Method-Mosaic/ npm run build
+# or
+VITE_BASE_PATH=/Method-Mosaic/ npm run deploy
+```
+
+Omit `VITE_BASE_PATH` for local development where the site is served from the
+root path.
+
 ## Project Structure
 ```
 .

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,9 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-// Ensure the built assets are served from the correct subpath when deploying
-// to GitHub Pages. The repository was renamed to "Method-Mosaic", so update
-// the default base path to match the new casing.
-const base = process.env.VITE_BASE_PATH || '/Method-Mosaic/'
+// Resolve the base path for assets. Prefer an explicit VITE_BASE_PATH env
+// variable, then fall back to Vite's BASE_URL, and finally default to '/'.
+const base = process.env.VITE_BASE_PATH || import.meta.env.BASE_URL || '/'
 
 export default defineConfig({
   base,


### PR DESCRIPTION
## Summary
- derive Vite base path from `VITE_BASE_PATH`, `import.meta.env.BASE_URL` or default `/`
- document `VITE_BASE_PATH` for deployments

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` with `VITE_BASE_PATH=/Method-Mosaic/` *(fails: vite not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4835b46f083298af9bbadb1419483