### PR TITLE
fix: guard import meta env in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,8 +3,10 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // Resolve the base path for assets. Prefer an explicit VITE_BASE_PATH env
-// variable, then fall back to Vite's BASE_URL, and finally default to '/'.
-const base = process.env.VITE_BASE_PATH || import.meta.env.BASE_URL || '/'
+// variable, then fall back to Vite's BASE_URL when available, and finally
+// default to '/'. Guard against `import.meta.env` being undefined when the
+// config is evaluated in a non-Vite context (e.g. during tests or builds).
+const base = process.env.VITE_BASE_PATH || import.meta.env?.BASE_URL || '/'
 
 export default defineConfig({
   base,


### PR DESCRIPTION
## Summary
- handle undefined `import.meta.env` when loading Vite config

## Testing
- `npm test` *(fails: vitest not found after npm install 403)*
- `npm run build` *(fails: vite not found after npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c48683e5008329af730e1383bea8c1