### PR TITLE
Rename Square layout mode to Mosaic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -561,7 +561,7 @@ export default function MethodMosaic() {
         <div className="max-w-[1400px] mx-auto">
         <div className="space-y-4">
           <input ref={fileInputRef} type="file" multiple accept="image/*" className="hidden" onChange={(e) => handleFiles(e.target.files)} />
-          <p className="text-sm text-neutral-500">Drop images • Paste • {canReorder ? "Drag tiles to reorder" : "Switch to Grid or Square to reorder"} • Reset order</p>
+          <p className="text-sm text-neutral-500">Drop images • Paste • {canReorder ? "Drag tiles to reorder" : "Switch to Grid or Mosaic to reorder"} • Reset order</p>
           <Card className="bg-transparent rounded-none shadow-none">
             <CardContent className="p-4 md:p-6">
               <div

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -95,7 +95,7 @@ function LayoutTab({ board, handleTemplateChange }) {
         <SelectBox value={board.layoutMode} onChange={board.setLayoutMode}>
           <option value="auto">Auto</option>
           <option value="grid">Grid</option>
-          <option value="square">Square</option>
+          <option value="square">Mosaic</option>
         </SelectBox>
       </div>
       <div className="space-y-2">


### PR DESCRIPTION
## Summary
- rename the Square layout mode label to Mosaic within the sidebar selector
- update the reorder helper text to reference Mosaic instead of Square

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9eab44afc8329817d99eed1ce5f5f