### PR TITLE
Adjust Vite base path defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ npm run deploy   # Build and publish dist/ to GitHub Pages
 
 When hosting the app under a subpath (such as GitHub Pages), set the
 `VITE_BASE_PATH` environment variable to ensure assets are loaded from the
-correct base URL.
+correct base URL. Deployments that serve the site from the root (including
+Vercel) work with the default `/` base, and Vercel can explicitly enforce this
+by setting `VITE_BASE_PATH=/` in the project environment variables.
 
 ```bash
 VITE_BASE_PATH=/Method-Mosaic/ npm run build

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,15 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-// Ensure the built assets are served from the correct subpath when deploying
-// to GitHub Pages. The repository was renamed to "Method-Mosaic", so update
-// the default base path to match the new casing.
-const base = process.env.VITE_BASE_PATH || '/Method-Mosaic/'
+// Ensure the built assets are served from the correct subpath when deploying.
+// Default to the root for platforms like Vercel, but fall back to the GitHub
+// Pages subpath when building in GitHub Actions or when explicitly requested.
+const requestedBase = process.env.VITE_BASE_PATH
+const base =
+  requestedBase ??
+  (process.env.GITHUB_PAGES === 'true' || process.env.GITHUB_ACTIONS === 'true'
+    ? '/Method-Mosaic/'
+    : '/')
 
 export default defineConfig({
   base,


### PR DESCRIPTION
## Summary
- default the Vite base path to `/` so platforms like Vercel serve assets correctly
- keep the GitHub Pages subpath only when requested via VITE_BASE_PATH or during GitHub builds
- document how to force the `/` base through environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca252d8430832990bac02ada4ddd14